### PR TITLE
Fix git push conflicts in PSN and quote workflows

### DIFF
--- a/.github/workflows/dynamic-quote.yaml
+++ b/.github/workflows/dynamic-quote.yaml
@@ -117,11 +117,36 @@ jobs:
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "Quote Bot"
           git add README.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
             git commit -m "💭 Update dynamic quote [skip ci]"
-            git push
+            
+            # Handle potential push conflicts with retries
+            MAX_RETRIES=3
+            RETRY_COUNT=0
+            
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if git push; then
+                echo "✅ Successfully pushed quote update"
+                break
+              else
+                echo "⚠️ Push failed, attempting to pull and retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                
+                # Pull latest changes and rebase our commit
+                git pull --rebase origin main
+                
+                # If this is the last retry, fail
+                if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+                  echo "❌ Failed to push after $MAX_RETRIES attempts"
+                  exit 1
+                fi
+                
+                # Wait a bit before retrying to avoid rapid succession
+                sleep 3
+              fi
+            done
           fi

--- a/.github/workflows/psn-activity.yaml
+++ b/.github/workflows/psn-activity.yaml
@@ -304,13 +304,38 @@ jobs:
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "PlayStation Bot"
           git add README.md
           if git diff --staged --quiet; then
             echo "No PSN activity changes to commit"
           else
             git commit -m "🎮 Update PlayStation gaming activity [skip ci]"
-            git push
+            
+            # Handle potential push conflicts with retries
+            MAX_RETRIES=3
+            RETRY_COUNT=0
+            
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if git push; then
+                echo "✅ Successfully pushed PSN activity update"
+                break
+              else
+                echo "⚠️ Push failed, attempting to pull and retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                
+                # Pull latest changes and rebase our commit
+                git pull --rebase origin main
+                
+                # If this is the last retry, fail
+                if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+                  echo "❌ Failed to push after $MAX_RETRIES attempts"
+                  exit 1
+                fi
+                
+                # Wait a bit before retrying to avoid rapid succession
+                sleep 5
+              fi
+            done
           fi
 
       - name: Cleanup


### PR DESCRIPTION
- Add retry logic with git pull --rebase for push conflicts
- Handle concurrent workflow execution conflicts
- Use descriptive bot names for commits
- Add proper error handling and retry attempts
- Prevent workflow failures from simultaneous pushes